### PR TITLE
Cargo.toml:edition change (2018 to 2021)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "configster"
 version = "0.1.2-dev"
 authors = ["Andy Alt <arch_stanton5995@proton.me>", "James Sherratt"]
-edition = "2018"
+edition = "2021"
 license = "MIT"
 description = "Rust library for parsing configuration files"
 homepage = "https://github.com/theimpossibleastronaut/configster"


### PR DESCRIPTION
Is there any reason not to do this?